### PR TITLE
Collection should be used, Local variable should not shadow class field

### DIFF
--- a/src/main/java/com/chenlb/mmseg4j/CharNode.java
+++ b/src/main/java/com/chenlb/mmseg4j/CharNode.java
@@ -2,6 +2,7 @@ package com.chenlb.mmseg4j;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -66,7 +67,7 @@ public class CharNode {
 	 * @return 至少返回一个包括 0的int
 	 * @author chenlb 2009-4-12 上午10:01:35
 	 */
-	public ArrayList<Integer> maxMatch(ArrayList<Integer> tailLens, char[] sen, int wordTailOffset) {
+	public List<Integer> maxMatch(List<Integer> tailLens, char[] sen, int wordTailOffset) {
 		return ktWordTails.maxMatch(tailLens, sen, wordTailOffset);
 	}
 	
@@ -115,7 +116,7 @@ public class CharNode {
 			return idx - offset + 1;
 		}
 		
-		public ArrayList<Integer> maxMatch(ArrayList<Integer> tailLens, char[] sen, int offset) {
+		public List<Integer> maxMatch(List<Integer> tailLens, char[] sen, int offset) {
 			TreeNode node = head;
 			for(int i=offset; i<sen.length; i++) {
 				node = node.subNode(sen[i]);

--- a/src/main/java/com/chenlb/mmseg4j/Dictionary.java
+++ b/src/main/java/com/chenlb/mmseg4j/Dictionary.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -231,7 +232,7 @@ public class Dictionary {
 			unitFile = new File(Dictionary.class.getResource("/data/units.dic").getFile());
 		}
 
-		final Map<Character, Object> unit = new HashMap<Character, Object>();
+		final Map<Character, Object> localUnit = new HashMap<Character, Object>();
 
 		long s = now();
 		int lineNum = load(fin, new FileLoading() {
@@ -240,12 +241,12 @@ public class Dictionary {
 				if(line.length() != 1) {
 					return;
 				}
-				unit.put(line.charAt(0), Dictionary.class);
+				localUnit.put(line.charAt(0), Dictionary.class);
 			}
 		});
 		log.info("[Dict Loading] unit loaded time="+(now()-s)+"ms, line="+lineNum+", on file="+unitFile.getName());
 
-		return unit;
+		return localUnit;
 	}
 
 	/**
@@ -419,7 +420,7 @@ public class Dictionary {
 		return 0;
 	}
 
-	public ArrayList<Integer> maxMatch(CharNode node, ArrayList<Integer> tailLens, char[] sen, int offset) {
+	public List<Integer> maxMatch(CharNode node, List<Integer> tailLens, char[] sen, int offset) {
 		tailLens.clear();
 		tailLens.add(0);
 		if(node != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1319 -  Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"
squid:HiddenFieldCheck -  Local variables should not shadow class fields

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck

Please let me know if you have any questions.

Zeeshan Asghar