### PR TITLE
double-quote error

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,19 @@ curl -XPOST http://localhost:9200/index/fulltext/_mapping -d'
 
 ```
 curl -XPOST http://localhost:9200/index/fulltext/1 -d'
-{content:"美国留给伊拉克的是个烂摊子吗"}
+{"content":"美国留给伊拉克的是个烂摊子吗"}
 '
 
 curl -XPOST http://localhost:9200/index/fulltext/2 -d'
-{content:"公安部：各地校车将享最高路权"}
+{"content":"公安部：各地校车将享最高路权"}
 '
 
 curl -XPOST http://localhost:9200/index/fulltext/3 -d'
-{content:"中韩渔警冲突调查：韩警平均每天扣1艘中国渔船"}
+{"content":"中韩渔警冲突调查：韩警平均每天扣1艘中国渔船"}
 '
 
 curl -XPOST http://localhost:9200/index/fulltext/4 -d'
-{content:"中国驻洛杉矶领事馆遭亚裔男子枪击 嫌犯已自首"}
+{"content":"中国驻洛杉矶领事馆遭亚裔男子枪击 嫌犯已自首"}
 '
 ```
 


### PR DESCRIPTION
curl -XPOST http://localhost:9200/index/fulltext/1 -d'
{content:"美国留给伊拉克的是个烂摊子吗"}
'
{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"failed to parse"}],"type":"mapper_parsing_exception","reason":"failed to parse","caused_by":{"type":"json_parse_exception","reason":"Unexpected character ('c' (code 99)): was expecting double-quote to start field name\n at [Source: org.elasticsearch.common.bytes.BytesReference$MarkSupportingStreamInputWrapper@2296656f; line: 2, column: 3]"}},"status":400}

The content(field name) without double-quote will cause an error